### PR TITLE
Set up GitHub Actions for page visit counter

### DIFF
--- a/.github/workflows/increment-visit-counter.yml
+++ b/.github/workflows/increment-visit-counter.yml
@@ -1,0 +1,31 @@
+name: Increment Visit Counter
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"  # This will run the Action every 5 minutes
+  workflow_dispatch: # This allows you to manually trigger the action
+
+jobs:
+  update-visit-counter:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Read and increment visit counter
+      run: |
+        # Read the current counter from counter.json
+        counter=$(jq .visitCount counter.json)
+        # Increment the counter by 1
+        new_counter=$((counter + 1))
+        # Update the counter.json file with the new count
+        jq ".visitCount = $new_counter" counter.json > temp.json && mv temp.json counter.json
+
+    - name: Commit updated counter
+      run: |
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@github.com"
+        git add counter.json
+        git commit -m "Increment visit counter"
+        git push

--- a/counter.json
+++ b/counter.json
@@ -1,0 +1,4 @@
+{
+    "visitCount": 0
+  }
+  

--- a/index.html
+++ b/index.html
@@ -95,6 +95,18 @@
             <span id="sun-icon" class="icon sun-icon">&#127774;</span>
         </label>
     </div>
+    <div id="visit-count">
+        Loading visit count...
+      </div>
+      
+      <script>
+        fetch('counter.json')
+          .then(response => response.json())
+          .then(data => {
+            document.getElementById('visit-count').textContent = "Page visits: " + data.visitCount;
+          });
+      </script>
+      
 </footer>
 
     <script src="script.js"></script>


### PR DESCRIPTION
- Created a counter.json file to hold the visit count.
- Set up a GitHub Actions workflow to update that counter at regular intervals.
- Committed the workflow and pushed it to your GitHub repository.
- Deployed the site via GitHub Pages to display the visit count.