### PR TITLE
Page visits counter

### DIFF
--- a/.github/workflows/increment-visit-counter.yml
+++ b/.github/workflows/increment-visit-counter.yml
@@ -2,7 +2,7 @@ name: Increment Visit Counter
 
 on:
   schedule:
-    - cron: "*/5 * * * *"  # This will run the Action every 5 minutes
+    - cron: "*/1 * * * *"  # This will run the Action every minute
   workflow_dispatch: # This allows you to manually trigger the action
 
 jobs:
@@ -13,6 +13,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Set up Git user
+      run: |
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@github.com"
+
     - name: Read and increment visit counter
       run: |
         # Read the current counter from counter.json
@@ -22,10 +27,10 @@ jobs:
         # Update the counter.json file with the new count
         jq ".visitCount = $new_counter" counter.json > temp.json && mv temp.json counter.json
 
-    - name: Commit updated counter
+    - name: Commit and push updated counter
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}  # Use the token from GitHub Secrets
       run: |
-        git config --global user.name "github-actions"
-        git config --global user.email "github-actions@github.com"
         git add counter.json
         git commit -m "Increment visit counter"
-        git push
+        git push https://github.com/${{ github.repository }}.git HEAD:${{ github.ref }} --force

--- a/.github/workflows/increment-visit-counter.yml
+++ b/.github/workflows/increment-visit-counter.yml
@@ -2,7 +2,7 @@ name: Increment Visit Counter
 
 on:
   schedule:
-    - cron: "*/1 * * * *"  # This will run the Action every minute
+    - cron: "*/2 * * * *"  # This will run the Action every minute
   workflow_dispatch: # This allows you to manually trigger the action
 
 jobs:


### PR DESCRIPTION
- Created a counter.json file to hold the visit count.
- Set up a GitHub Actions workflow to update that counter at regular intervals.
- Committed the workflow and pushed it to your GitHub repository.
- Deployed the site via GitHub Pages to display the visit count.